### PR TITLE
Fixed crash when piping into less

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -278,7 +278,8 @@ bro.commands['help'].summary = 'Display global or [command] help documentation.'
 /* Display the bro page for the provided command */
 var display = function(data, remaining) {
   var list = JSON.parse(data);
-  var separator = Array(process.stdout.columns - 5).join('.') + '\n';
+var columns = process.stdout.columns || 80;
+  var separator = Array(columns - 5).join('.') + '\n';
 
   // the display string for the command
   var cmd_display = remaining.join(' ');


### PR DESCRIPTION
process.stdout.columns is undefined when piping into less, so I made it default to
80 when it is not defined.
